### PR TITLE
Chore: Replaced the "Back to Community Events" link on the WiDS page 

### DIFF
--- a/templates/2026/co-events/women_in_data_science.html
+++ b/templates/2026/co-events/women_in_data_science.html
@@ -186,9 +186,11 @@
         Be part of a growing community of women shaping the future of data science in Africa.
         More details on registration and the programme will be shared soon.
       </p>
-      <a href="{% url 'pycon2026:community' %}"
+      <a href="https://forms.gle/T6MeisrdFywkvvPVA"
+         target="_blank"
+         rel="noopener noreferrer"
          class="btn-teal">
-        Back to Community Events
+        Apply Now
       </a>
     </div>
 


### PR DESCRIPTION
 Replaced the "Back to Community Events" link on the WiDS page  CTA with an "Apply Now" button linking to the Google form